### PR TITLE
[WIP] Stream support

### DIFF
--- a/src/Riverline/MultiPartParser/Part.php
+++ b/src/Riverline/MultiPartParser/Part.php
@@ -58,10 +58,10 @@ class Part
 
         // Is MultiPart ?
         $contentType = $this->getHeader('Content-Type');
-        if ('multipart' === strstr(self::getHeaderValue($contentType), '/', true)) {
+        if ('multipart' === strstr(static::getHeaderValue($contentType), '/', true)) {
             // MultiPart !
             $this->multipart = true;
-            $boundary = self::getHeaderOption($contentType, 'boundary');
+            $boundary = static::getHeaderOption($contentType, 'boundary');
 
             if (null === $boundary) {
                 throw new \InvalidArgumentException("Can't find boundary in content type");
@@ -78,7 +78,7 @@ class Part
             $parts = preg_split('/\r\n'.$separator.'\r\n/', $matches[1]);
 
             foreach ($parts as $part) {
-                $this->parts[] = new self($part);
+                $this->parts[] = new static($part);
             }
         } else {
             // Decode
@@ -95,7 +95,7 @@ class Part
             // Convert to UTF-8 ( Not if binary or 7bit ( aka Ascii ) )
             if (!in_array($encoding, array('binary', '7bit'))) {
                 // Charset
-                $charset = self::getHeaderOption($contentType, 'charset');
+                $charset = static::getHeaderOption($contentType, 'charset');
                 if (null === $charset) {
                     // Try to detect
                     $charset = mb_detect_encoding($body) ?: 'utf-8';
@@ -243,7 +243,7 @@ class Part
      */
     static public function getHeaderValue($header)
     {
-        list($value) = self::parseHeaderContent($header);
+        list($value) = static::parseHeaderContent($header);
 
         return $value;
     }
@@ -254,7 +254,7 @@ class Part
      */
     static public function getHeaderOptions($header)
     {
-        list(,$options) = self::parseHeaderContent($header);
+        list(,$options) = static::parseHeaderContent($header);
 
         return $options;
     }
@@ -267,7 +267,7 @@ class Part
      */
     static public function getHeaderOption($header, $key, $default = null)
     {
-        $options = self::getHeaderOptions($header);
+        $options = static::getHeaderOptions($header);
 
         if (isset($options[$key])) {
             return $options[$key];
@@ -284,7 +284,7 @@ class Part
         // Find Content-Disposition
         $contentType = $this->getHeader('Content-Type');
 
-        return self::getHeaderValue($contentType) ?: 'application/octet-stream';
+        return static::getHeaderValue($contentType) ?: 'application/octet-stream';
     }
 
     /**
@@ -295,7 +295,7 @@ class Part
         // Find Content-Disposition
         $contentDisposition = $this->getHeader('Content-Disposition');
 
-        return self::getHeaderOption($contentDisposition, 'name');
+        return static::getHeaderOption($contentDisposition, 'name');
     }
 
     /**
@@ -306,7 +306,7 @@ class Part
         // Find Content-Disposition
         $contentDisposition = $this->getHeader('Content-Disposition');
 
-        return self::getHeaderOption($contentDisposition, 'filename');
+        return static::getHeaderOption($contentDisposition, 'filename');
     }
 
     /**

--- a/src/Riverline/MultiPartParser/Part.php
+++ b/src/Riverline/MultiPartParser/Part.php
@@ -112,6 +112,7 @@ class Part
             return $this;
         }
         // Get multi-part content
+        // @todo boundary might appear on boundary, we need to handle this
         while (false === ($startBoundaryOccurrence = strpos($body, '--'.$this->boundary.self::CRLF))) {
             if (feof($stream)) {
                 throw new InvalidArgumentException("Can't find multi-part content");
@@ -164,6 +165,8 @@ class Part
     }
 
     /**
+     * @todo boundary might appear on boundary, we need to handle this
+     *
      * @param resource $stream
      * @param int      $chunkSize
      * @param string   $content

--- a/src/Riverline/MultiPartParser/Part.php
+++ b/src/Riverline/MultiPartParser/Part.php
@@ -46,7 +46,7 @@ class Part
     protected function parseContentString($content)
     {
         // Split headers and body
-        $splits = preg_split('/(\r?\n){2}/', $content, 2);
+        $splits = preg_split('/(\r\n){2}/', $content, 2);
 
         if (count($splits) < 2) {
             throw new \InvalidArgumentException("Content is not valid, can't split headers and content");
@@ -70,12 +70,12 @@ class Part
             $separator = '--'.preg_quote($boundary, '/');
 
             // Get multi-part content
-            if (0 === preg_match('/'.$separator.'\r?\n(.+)\r?\n'.$separator.'--/s', $body, $matches)) {
+            if (0 === preg_match('/'.$separator.'\r\n(.+)\r\n'.$separator.'--/s', $body, $matches)) {
                 throw new \InvalidArgumentException("Can't find multi-part content");
             }
 
             // Get parts
-            $parts = preg_split('/\r?\n'.$separator.'\r?\n/', $matches[1]);
+            $parts = preg_split('/\r\n'.$separator.'\r\n/', $matches[1]);
 
             foreach ($parts as $part) {
                 $this->parts[] = new self($part);
@@ -121,7 +121,7 @@ class Part
         // Regroup multiline headers
         $currentHeader = '';
         $headerLines = array();
-        foreach (preg_split('/\r?\n/', $headers) as $line) {
+        foreach (preg_split('/\r\n/', $headers) as $line) {
             if (empty($line)) {
                 continue;
             }

--- a/src/Riverline/MultiPartParser/Part.php
+++ b/src/Riverline/MultiPartParser/Part.php
@@ -117,7 +117,7 @@ class Part
                 throw new InvalidArgumentException("Can't find multi-part content");
             }
 
-            $body .= fread($stream, $chunkSize);
+            $body = fread($stream, $chunkSize);
         }
 
         // strlen doesn't take into account trailing CRLF since we'll need it below

--- a/src/Riverline/MultiPartParser/Part.php
+++ b/src/Riverline/MultiPartParser/Part.php
@@ -31,6 +31,7 @@ class Part
     /**
      * MultiPart constructor.
      * @param string $content
+     * @throws \InvalidArgumentException
      */
     public function __construct($content)
     {
@@ -166,7 +167,7 @@ class Part
 
     /**
      * @return string
-     * @throw \LogicException if is multipart
+     * @throws \LogicException if is multipart
      */
     public function getBody()
     {
@@ -320,7 +321,7 @@ class Part
 
     /**
      * @return Part[]
-     * @throw \LogicException if is not multipart
+     * @throws \LogicException if is not multipart
      */
     public function getParts()
     {
@@ -334,7 +335,7 @@ class Part
     /**
      * @param string $name
      * @return Part[]
-     * @throw \LogicException if is not multipart
+     * @throws \LogicException if is not multipart
      */
     public function getPartsByName($name)
     {


### PR DESCRIPTION
Stream support implementation, fixes #1

Instead of having constructor, `::fromString()` and `::fromStream()` factory methods added in order to provide distinction from calls and allow calling constructor just for creating empty object (constructor is deprecated, but still behaves as it was before, no tests were changed).

Code is highly refactored in order to work with streams as primary thing and string processing under the hood also uses code for stream without any visible overhead. Also optimizations added like avoiding regular expressions usage.

After these changes it is possible to handle request that are few GiB long without any issues.

Also tests are not added for streams, but I'd like to see my other PRs from today merged, then I'll rebase and add tests.

For review, please, take a look at commits, total diff is pretty difficult to understand