### PR TITLE
Fix for boundary \r part of body

### DIFF
--- a/src/Riverline/MultiPartParser/Part.php
+++ b/src/Riverline/MultiPartParser/Part.php
@@ -107,7 +107,7 @@ class Part
             $separator = '--'.preg_quote($boundary, '/');
 
             // Get multi-part content
-            if (0 === preg_match('/'.$separator.'\r?\n(.+)\r?\n'.$separator.'--/s', $body, $matches)) {
+            if (0 === preg_match('/'.$separator.'\r?\n(.+?)\r?\n'.$separator.'--/s', $body, $matches)) {
                 throw new \InvalidArgumentException("Can't find multi-part content");
             }
 

--- a/tests/Riverline/MultiPartParser/PartTest.php
+++ b/tests/Riverline/MultiPartParser/PartTest.php
@@ -104,6 +104,20 @@ class PartTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test correct part content (e.g. \r of separator not part of body)
+     */
+    public function testPartContent()
+    {
+        $content = file_get_contents(__DIR__.'/../../data/simple_multipart.txt');
+
+        $part = new Part($content);
+
+        $foo = $part->getPartsByName('foo');
+
+        self::assertEquals("bar", $foo[0]->getBody());
+    }
+
+    /**
      * Test header helpers
      */
     public function testHeaderHelpers()


### PR DESCRIPTION
Added test showing that current behaviour tags \r of boundary onto a part's body. Also made regex non-greedy to fix the issue.