### PR TITLE
Create a new parser for stream input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: php
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
-  - hhvm
-matrix:
-  include:
-    - php: 5.3
-      dist: precise
-before_script: composer install
+  - 7.1
+  - 7.2
+  - 7.3
+install: composer install

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 ## Requirements
 
-* PHP 5.3 or HHVM
+* PHP >= 5.6
 
 ## Installation
 
-``Riverline\MultiPartParse`` is compatible with composer and any prs-0 autoloader.
+``Riverline\MultiPartParse`` is compatible with composer and any psr-0/psr-4 autoloader.
 
 ```
 composer require riverline/multipart-parser
@@ -23,9 +23,10 @@ composer require riverline/multipart-parser
 ```php
 <?php
 
-use Riverline\MultiPartParser\Part;
+use Riverline\MultiPartParser\StreamedPart;
 
-$content = <<<EOL
+// Prepare a test stream
+$data = <<<EOL
 User-Agent: curl/7.21.2 (x86_64-apple-darwin)
 Host: localhost:8080
 Accept: */*
@@ -46,8 +47,11 @@ Content-Type: text/plain
 File content
 ------------------------------83ff53821b7c--
 EOL;
+$stream = fopen('php://temp', 'rw');
+fwrite($stream, $data);
+rewind($stream);
 
-$document = new Part($content);
+$document = new StreamedPart($stream);
 
 if ($document->isMultiPart()) {
     $parts = $document->getParts();
@@ -63,8 +67,8 @@ if ($document->isMultiPart()) {
     $contentDisposition = $parts[0]->getHeader('Content-Disposition');
     echo $contentDisposition; // Output Content-Disposition: form-data; name="foo"
     // Helpers
-    echo Part::getHeaderValue($contentDisposition); // Output form-data
-    echo Part::getHeaderOption($contentDisposition, 'name'); // Output foo
+    echo StreamedPart::getHeaderValue($contentDisposition); // Output form-data
+    echo StreamedPart::getHeaderOption($contentDisposition, 'name'); // Output foo
 
     // File helper
     if ($parts[2]->isFile()) {
@@ -73,3 +77,8 @@ if ($document->isMultiPart()) {
     }
 }
 ```
+
+## Backward compatibility
+
+The old `Part` parser is now deprecated and replaced with a wrapper class that create a temporary stream
+from the string content and call the new `StreamedPart` parser.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ## What is Riverline\MultiPartParser
 
-``Riverline\MultiPartParse`` is a one class lib to parse multipart document ( multipart email, multipart form, etc ...) and manage each part encoding and charset to extract their content.
+``Riverline\MultiPartParse`` is a one class library to parse multipart document ( multipart email, multipart form, etc ...) 
+and manage each part encoding and charset to extract their content.
 
 ## Requirements
 
@@ -76,6 +77,19 @@ if ($document->isMultiPart()) {
         echo $parts[2]->getMimeType(); // Output text/plain
     }
 }
+```
+
+## Converters
+
+The libary also provide three converters to quickly parse `PSR-7`, `HttpFoundation` and native requests.
+
+```php
+<?php
+
+use \Riverline\MultiPartParser\Converters;
+
+// Parse $_SERVER and STDIN
+$document = Converters\Globals::convert();
 ```
 
 ## Backward compatibility

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,10 @@
     "ext-mbstring": "*"
   },
   "require-dev":{
-    "phpunit/phpunit": "^4.7 || ^5.2"
+    "phpunit/phpunit":  "^4.7 || ^5.2",
+    "psr/http-message": "^1.0",
+    "symfony/psr-http-message-bridge": "^1.1",
+    "zendframework/zend-diactoros": "^1.0"
   },
   "autoload":{
     "psr-4":{

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "authors":[
     {
       "name":"Romain Cambien",
-      "email":"romain@riverline.fr"
+      "email":"romain@cambien.net"
     },
     {
       "name":"Riverline",
@@ -15,7 +15,8 @@
     }
   ],
   "require":{
-    "php":           ">=5.3"
+    "php":          ">=5.4.4",
+    "ext-mbstring": "*"
   },
   "require-dev":{
     "phpunit/phpunit": "^4.7 || ^5.2"

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     "phpunit/phpunit": "^4.7 || ^5.2"
   },
   "autoload":{
-    "psr-0":{
-      "Riverline\\MultiPartParser": "src/"
+    "psr-4":{
+      "Riverline\\MultiPartParser\\": "src/Riverline/MultiPartParser/"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require":{
-    "php":          ">=5.4.4",
+    "php":          ">=5.6.0",
     "ext-mbstring": "*"
   },
   "require-dev":{

--- a/src/Riverline/MultiPartParser/Converters/Globals.php
+++ b/src/Riverline/MultiPartParser/Converters/Globals.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the MultiPartParser package.
+ *
+ * (c) Romain Cambien <romain@cambien.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Riverline\MultiPartParser\Converters;
+
+use Riverline\MultiPartParser\StreamedPart;
+
+/**
+ * Class GlobalsTest
+ */
+class Globals
+{
+    /**
+     * @param bool|resource $input
+     *
+     * @return StreamedPart
+     */
+    public static function convert($input = STDIN)
+    {
+        $stream = fopen('php://temp', 'rw');
+
+        foreach ($_SERVER as $key => $value) {
+            if (0 === strpos($key, 'HTTP_')) {
+                $key = str_replace('_', '-', strtolower(substr($key, 5)));
+                fwrite($stream, "$key: $value\r\n");
+            } elseif (in_array($key, ['CONTENT_LENGTH', 'CONTENT_MD5', 'CONTENT_TYPE'])) {
+                $key = str_replace('_', '-', strtolower($key));
+                fwrite($stream, "$key: $value\r\n");
+            }
+        }
+
+        fwrite($stream, "\r\n");
+
+        stream_copy_to_stream($input, $stream);
+
+        rewind($stream);
+
+        return new StreamedPart($stream);
+    }
+}

--- a/src/Riverline/MultiPartParser/Converters/HttpFoundation.php
+++ b/src/Riverline/MultiPartParser/Converters/HttpFoundation.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the MultiPartParser package.
+ *
+ * (c) Romain Cambien <romain@cambien.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Riverline\MultiPartParser\Converters;
+
+use Riverline\MultiPartParser\StreamedPart;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class HttpFoundation
+ */
+class HttpFoundation
+{
+    /**
+     * @param Request $request
+     *
+     * @return StreamedPart
+     */
+    public static function convert(Request $request)
+    {
+        $stream = fopen('php://temp', 'rw');
+
+        fwrite($stream, (string) $request->headers."\r\n");
+
+        stream_copy_to_stream($request->getContent(true), $stream);
+
+        rewind($stream);
+
+        return new StreamedPart($stream);
+    }
+}

--- a/src/Riverline/MultiPartParser/Converters/PSR7.php
+++ b/src/Riverline/MultiPartParser/Converters/PSR7.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the MultiPartParser package.
+ *
+ * (c) Romain Cambien <romain@cambien.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Riverline\MultiPartParser\Converters;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Riverline\MultiPartParser\StreamedPart;
+
+/**
+ * Class PSR7
+ */
+class PSR7
+{
+    /**
+     * @param ServerRequestInterface $serverRequest
+     *
+     * @return StreamedPart
+     */
+    public static function convert(ServerRequestInterface $serverRequest)
+    {
+        $stream = fopen('php://temp', 'rw');
+
+        foreach ($serverRequest->getHeaders() as $key => $values) {
+            foreach ($values as $value) {
+                fwrite($stream, "$key: $value\r\n");
+            }
+        }
+        fwrite($stream, "\r\n");
+
+        $body = $serverRequest->getBody();
+        $body->rewind();
+
+        while (!$body->eof()) {
+            fwrite($stream, $body->read(1024));
+        }
+
+        rewind($stream);
+
+        return new StreamedPart($stream);
+    }
+}

--- a/src/Riverline/MultiPartParser/Part.php
+++ b/src/Riverline/MultiPartParser/Part.php
@@ -1,337 +1,36 @@
 <?php
 
+/*
+ * This file is part of the MultiPartParser package.
+ *
+ * (c) Romain Cambien <romain@cambien.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Riverline\MultiPartParser;
 
 /**
  * Class Part
- * @package Riverline\MultiPartParser
+ *
+ * @deprecated Wrapper class, use StreamedPart
  */
-class Part
+class Part extends StreamedPart
 {
     /**
-     * @var array
-     */
-    protected $headers;
-
-    /**
-     * @var string
-     */
-    protected $body;
-
-    /**
-     * @var Part[]
-     */
-    protected $parts = array();
-
-    /**
-     * @var bool
-     */
-    protected $multipart = false;
-
-    /**
      * MultiPart constructor.
+     *
      * @param string $content
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct($content)
     {
-        // Split headers and body
-        $splits = preg_split('/(\r?\n){2}/', $content, 2);
+        $stream = fopen('php://temp', 'rw');
+        fwrite($stream, $content);
+        rewind($stream);
 
-        if (count($splits) < 2) {
-            throw new \InvalidArgumentException("Content is not valid, can't split headers and content");
-        }
-
-        list ($headers, $body) = $splits;
-
-        // Regroup multiline headers
-        $currentHeader = '';
-        $headerLines = array();
-        foreach (preg_split('/\r?\n/', $headers) as $line) {
-            if (empty($line)) {
-                continue;
-            }
-            if (preg_match('/^\h+(.+)/', $line, $matches)) {
-                // Multi line header
-                $currentHeader .= ' '.$matches[1];
-            } else {
-                if (!empty($currentHeader)) {
-                    $headerLines[] = $currentHeader;
-                }
-                $currentHeader = trim($line);
-            }
-        }
-
-        if (!empty($currentHeader)) {
-            $headerLines[] = $currentHeader;
-        }
-
-        // Parse headers
-        $this->headers = array();
-        foreach ($headerLines as $line) {
-            $lineSplit = explode(':', $line, 2);
-            if (2 === count($lineSplit)) {
-                list($key, $value) = $lineSplit;
-                // Decode value
-                $value = mb_decode_mimeheader(trim($value));
-            } else {
-                // Bogus header
-                $key = $lineSplit[0];
-                $value = '';
-            }
-            // Case-insensitive key
-            $key = strtolower($key);
-            if (!isset($this->headers[$key])) {
-                $this->headers[$key] = $value;
-            } else {
-                if (!is_array($this->headers[$key])) {
-                    $this->headers[$key] = (array) $this->headers[$key];
-                }
-                $this->headers[$key][] = $value;
-            }
-        }
-
-        // Is MultiPart ?
-        $contentType = $this->getHeader('Content-Type');
-        if ('multipart' === strstr(self::getHeaderValue($contentType), '/', true)) {
-            // MultiPart !
-            $this->multipart = true;
-            $boundary = self::getHeaderOption($contentType, 'boundary');
-
-            if (null === $boundary) {
-                throw new \InvalidArgumentException("Can't find boundary in content type");
-            }
-
-            $separator = '--'.preg_quote($boundary, '/');
-
-            // Get multi-part content
-            if (0 === preg_match('/'.$separator.'\r?\n(.+?)\r?\n'.$separator.'--/s', $body, $matches)) {
-                throw new \InvalidArgumentException("Can't find multi-part content");
-            }
-
-            // Get parts
-            $parts = preg_split('/\r?\n'.$separator.'\r?\n/', $matches[1]);
-
-            foreach ($parts as $part) {
-                $this->parts[] = new self($part);
-            }
-        } else {
-            // Decode
-            $encoding = strtolower($this->getHeader('Content-Transfer-Encoding'));
-            switch ($encoding) {
-                case 'base64':
-                    $body = base64_decode($body);
-                    break;
-                case 'quoted-printable':
-                    $body = quoted_printable_decode($body);
-                    break;
-            }
-
-            // Convert to UTF-8 ( Not if binary or 7bit ( aka Ascii ) )
-            if (!in_array($encoding, array('binary', '7bit'))) {
-                // Charset
-                $charset = self::getHeaderOption($contentType, 'charset');
-                if (null === $charset) {
-                    // Try to detect
-                    $charset = mb_detect_encoding($body) ?: 'utf-8';
-                }
-
-                // Only convert if not UTF-8
-                if ('utf-8' !== strtolower($charset)) {
-                    $body = mb_convert_encoding($body, 'utf-8', $charset);
-                }
-            }
-
-            $this->body = $body;
-        }
-    }
-
-    /**
-     * @return bool
-     */
-    public function isMultiPart()
-    {
-        return $this->multipart;
-    }
-
-    /**
-     * @return string
-     * @throws \LogicException if is multipart
-     */
-    public function getBody()
-    {
-        if ($this->isMultiPart()) {
-            throw new \LogicException("MultiPart content, there aren't body");
-        } else {
-            return $this->body;
-        }
-    }
-
-    /**
-     * @return array
-     */
-    public function getHeaders()
-    {
-        return $this->headers;
-    }
-
-    /**
-     * @param string $key
-     * @param mixed  $default
-     * @return mixed
-     */
-    public function getHeader($key, $default = null)
-    {
-        // Case-insensitive key
-        $key = strtolower($key);
-        if (isset($this->headers[$key])) {
-            return $this->headers[$key];
-        } else {
-            return $default;
-        }
-    }
-
-    /**
-     * @param string $content
-     * @return array
-     */
-    static protected function parseHeaderContent($content)
-    {
-        $parts = explode(';', $content);
-        $headerValue = array_shift($parts);
-        $options = array();
-        // Parse options
-        foreach ($parts as $part) {
-            if (!empty($part)) {
-                $partSplit = explode('=', $part, 2);
-                if (2 === count($partSplit)) {
-                    list ($key, $value) = $partSplit;
-                    if ('*' === substr($key, -1)) {
-                        // RFC 5987
-                        $key = substr($key, 0, -1);
-                        if (preg_match("/(?P<charset>[\w!#$%&+^_`{}~-]+)'(?P<language>[\w-]*)'(?P<value>.*)$/", $value, $matches)) {
-                            $value = mb_convert_encoding(rawurldecode($matches['value']), 'utf-8', $matches['charset']);
-                        }
-                    }
-                    $options[trim($key)] = trim($value, ' "');
-                } else {
-                    // Bogus option
-                    $options[$partSplit[0]] = '';
-                }
-            }
-        }
-
-        return array($headerValue, $options);
-    }
-
-    /**
-     * @param string $header
-     * @return string
-     */
-    static public function getHeaderValue($header)
-    {
-        list($value) = self::parseHeaderContent($header);
-
-        return $value;
-    }
-
-    /**
-     * @param string $header
-     * @return array
-     */
-    static public function getHeaderOptions($header)
-    {
-        list(, $options) = self::parseHeaderContent($header);
-
-        return $options;
-    }
-
-    /**
-     * @param string $header
-     * @param string $key
-     * @param mixed  $default
-     * @return mixed
-     */
-    static public function getHeaderOption($header, $key, $default = null)
-    {
-        $options = self::getHeaderOptions($header);
-
-        if (isset($options[$key])) {
-            return $options[$key];
-        } else {
-            return $default;
-        }
-    }
-
-    /**
-     * @return string
-     */
-    public function getMimeType()
-    {
-        // Find Content-Disposition
-        $contentType = $this->getHeader('Content-Type');
-
-        return self::getHeaderValue($contentType) ?: 'application/octet-stream';
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getName()
-    {
-        // Find Content-Disposition
-        $contentDisposition = $this->getHeader('Content-Disposition');
-
-        return self::getHeaderOption($contentDisposition, 'name');
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getFileName()
-    {
-        // Find Content-Disposition
-        $contentDisposition = $this->getHeader('Content-Disposition');
-
-        return self::getHeaderOption($contentDisposition, 'filename');
-    }
-
-    /**
-     * @return bool
-     */
-    public function isFile()
-    {
-        return !is_null($this->getFileName());
-    }
-
-    /**
-     * @return Part[]
-     * @throws \LogicException if is not multipart
-     */
-    public function getParts()
-    {
-        if ($this->isMultiPart()) {
-            return $this->parts;
-        } else {
-            throw new \LogicException("Not MultiPart content, there aren't any parts");
-        }
-    }
-
-    /**
-     * @param string $name
-     * @return Part[]
-     * @throws \LogicException if is not multipart
-     */
-    public function getPartsByName($name)
-    {
-        $parts = array();
-
-        foreach ($this->getParts() as $part) {
-            if ($part->getName() === $name) {
-                $parts[] = $part;
-            }
-        }
-
-        return $parts;
+        parent::__construct($stream);
     }
 }

--- a/src/Riverline/MultiPartParser/StreamedPart.php
+++ b/src/Riverline/MultiPartParser/StreamedPart.php
@@ -1,0 +1,409 @@
+<?php
+
+/*
+ * This file is part of the MultiPartParser package.
+ *
+ * (c) Romain Cambien <romain@cambien.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Riverline\MultiPartParser;
+
+/**
+ * Class StreamedPart
+ */
+class StreamedPart
+{
+    /**
+     * @var resource
+     */
+    private $stream;
+
+    /**
+     * @var array
+     */
+    private $headers;
+
+    /**
+     * @var int
+     */
+    private $bodyOffset;
+
+    /**
+     * @var StreamedPart[]
+     */
+    private $parts = array();
+
+    /**
+     * StreamParser constructor.
+     *
+     * @param resource $stream
+     */
+    public function __construct($stream)
+    {
+        if (false === is_resource($stream)) {
+            throw new \InvalidArgumentException('Input is not a stream');
+        }
+
+        $this->stream = $stream;
+
+        // Reset the stream
+        rewind($this->stream);
+
+        // Parse headers
+        $endOfHeaders = false;
+        $bufferSize = 8192;
+        $headerLines = [];
+        $buffer = '';
+
+        while (false !== ($line = fgets($this->stream, $bufferSize))) {
+            // Append to buffer
+            $buffer .= rtrim($line);
+
+            if (strlen($line) === $bufferSize-1) {
+                // EOL not reached, continue
+                continue;
+            }
+
+            if ('' === $buffer) {
+                // Empty line cause by double new line, we reached the end of the headers section
+                $endOfHeaders = true;
+                break;
+            }
+
+            // Detect horizontal whitescapes before header
+            $trimmed = ltrim($buffer);
+            if (strlen($buffer) > strlen($trimmed)) {
+                // Multi lines header, append to previous line
+                $headerLines[count($headerLines)-1] .= "\x20".$trimmed;
+            } else {
+                $headerLines[] = $buffer;
+            }
+
+            // Reset buffer
+            $buffer = '';
+        }
+
+        if (false === $endOfHeaders) {
+            throw new \InvalidArgumentException('Content is not valid');
+        }
+
+        $this->headers = [];
+        foreach ($headerLines as $line) {
+            $lineSplit = explode(':', $line, 2);
+
+            if (2 === count($lineSplit)) {
+                list($key, $value) = $lineSplit;
+                // Decode value
+                $value = mb_decode_mimeheader(trim($value));
+            } else {
+                // Bogus header
+                $key = $lineSplit[0];
+                $value = '';
+            }
+
+            // Case-insensitive key
+            $key = strtolower($key);
+            if (false === key_exists($key, $this->headers)) {
+                $this->headers[$key] = $value;
+            } else {
+                // Already got an header with this key, convert to array
+                if (false === is_array($this->headers[$key])) {
+                    $this->headers[$key] = (array) $this->headers[$key];
+                }
+                $this->headers[$key][] = $value;
+            }
+        }
+
+        $this->bodyOffset = ftell($stream);
+
+        // Is MultiPart ?
+        if ($this->isMultiPart()) {
+            // MultiPart !
+            $boundary = self::getHeaderOption($this->getHeader('Content-Type'), 'boundary');
+
+            if (null === $boundary) {
+                throw new \InvalidArgumentException("Can't find boundary in content type");
+            }
+
+            $separator = '--'.$boundary;
+
+            $partOffset = 0;
+            $endOfBody = false;
+            while ($line = fgets($this->stream, $bufferSize)) {
+                // Search the seperator
+                if (substr($line, 0, strlen($separator)) === $separator) {
+                    if ($partOffset > 0) {
+                        $currentOffset = ftell($this->stream);
+                        $partStream = fopen('php://temp', 'rw');
+                        $partLength = $currentOffset - (strlen($line)) - $partOffset;
+                        /* FIXME replace hardcoded number of newline length */
+                        stream_copy_to_stream($this->stream, $partStream, $partLength - 2, $partOffset);
+                        $this->parts[] = new self($partStream);
+                        fseek($this->stream, $currentOffset);
+                    }
+
+                    // We reach the end separator
+                    if (trim($line) === $separator.'--') {
+                        $endOfBody = true;
+                        break;
+                    }
+
+                    $partOffset = ftell($this->stream);
+                }
+            }
+
+
+            if (0 === count($this->parts)
+                || false === $endOfBody
+            ) {
+                throw new \LogicException("Can't find multi-part content");
+            }
+        }
+    }
+
+
+    /**
+     * @return bool
+     */
+    public function isMultiPart()
+    {
+        return ('multipart' === mb_strstr(
+            self::getHeaderValue($this->getHeader('Content-Type')),
+            '/',
+            true
+        ));
+    }
+
+    /**
+     * @return string
+     *
+     * @throws \LogicException if is multipart
+     */
+    public function getBody()
+    {
+        if ($this->isMultiPart()) {
+            throw new \LogicException("MultiPart content, there aren't body");
+        }
+
+        $body = stream_get_contents($this->stream, -1, $this->bodyOffset);
+
+        // Decode
+        $encoding = strtolower($this->getHeader('Content-Transfer-Encoding'));
+        switch ($encoding) {
+            case 'base64':
+                $body = base64_decode($body);
+                break;
+            case 'quoted-printable':
+                $body = quoted_printable_decode($body);
+                break;
+        }
+
+        // Convert to UTF-8 ( Not if binary or 7bit ( aka Ascii ) )
+        if (false === in_array($encoding, array('binary', '7bit'))) {
+            // Charset
+            $contentType = $this->getHeader('Content-Type');
+            $charset = self::getHeaderOption($contentType, 'charset');
+            if (null === $charset) {
+                // Try to detect
+                $charset = mb_detect_encoding($body) ?: 'utf-8';
+            }
+
+            // Only convert if not UTF-8
+            if ('utf-8' !== strtolower($charset)) {
+                $body = mb_convert_encoding($body, 'utf-8', $charset);
+            }
+        }
+
+        return $body;
+    }
+
+    /**
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @param mixed  $default
+     *
+     * @return mixed
+     */
+    public function getHeader($key, $default = null)
+    {
+        // Case-insensitive key
+        $key = strtolower($key);
+
+        if (false === isset($this->headers[$key])) {
+            return $default;
+        }
+
+        return $this->headers[$key];
+    }
+
+    /**
+     * @param string $header
+     *
+     * @return string
+     */
+    public static function getHeaderValue($header)
+    {
+        list($value) = self::parseHeaderContent($header);
+
+        return $value;
+    }
+
+    /**
+     * @param string $header
+     *
+     * @return array
+     */
+    public static function getHeaderOptions($header)
+    {
+        list(, $options) = self::parseHeaderContent($header);
+
+        return $options;
+    }
+
+    /**
+     * @param string $header
+     * @param string $key
+     *
+     * @param mixed  $default
+     *
+     * @return mixed
+     */
+    public static function getHeaderOption($header, $key, $default = null)
+    {
+        $options = self::getHeaderOptions($header);
+
+        if (false === isset($options[$key])) {
+            return $default;
+        }
+
+        return $options[$key];
+    }
+
+    /**
+     * @return string
+     */
+    public function getMimeType()
+    {
+        // Find Content-Disposition
+        $contentType = $this->getHeader('Content-Type');
+
+        return self::getHeaderValue($contentType) ?: 'application/octet-stream';
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getName()
+    {
+        // Find Content-Disposition
+        $contentDisposition = $this->getHeader('Content-Disposition');
+
+        return self::getHeaderOption($contentDisposition, 'name');
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFileName()
+    {
+        // Find Content-Disposition
+        $contentDisposition = $this->getHeader('Content-Disposition');
+
+        return self::getHeaderOption($contentDisposition, 'filename');
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFile()
+    {
+        return (false === is_null($this->getFileName()));
+    }
+
+    /**
+     * @return StreamedPart[]
+     *
+     * @throws \LogicException if is not multipart
+     */
+    public function getParts()
+    {
+        if (false === $this->isMultiPart()) {
+            throw new \LogicException("Not MultiPart content, there aren't any parts");
+        }
+
+        return $this->parts;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return Part[]
+     *
+     * @throws \LogicException if is not multipart
+     */
+    public function getPartsByName($name)
+    {
+        $parts = array();
+
+        foreach ($this->getParts() as $part) {
+            if ($part->getName() === $name) {
+                $parts[] = $part;
+            }
+        }
+
+        return $parts;
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return array
+     */
+    private static function parseHeaderContent($content)
+    {
+        $parts = explode(';', $content);
+        $headerValue = array_shift($parts);
+        $options = array();
+        // Parse options
+        foreach ($parts as $part) {
+            if (false === empty($part)) {
+                $partSplit = explode('=', $part, 2);
+                if (2 === count($partSplit)) {
+                    list ($key, $value) = $partSplit;
+                    if ('*' === substr($key, -1)) {
+                        // RFC 5987
+                        $key = substr($key, 0, -1);
+                        if (preg_match(
+                            "/(?P<charset>[\w!#$%&+^_`{}~-]+)'(?P<language>[\w-]*)'(?P<value>.*)$/",
+                            $value,
+                            $matches
+                        )) {
+                            $value = mb_convert_encoding(
+                                rawurldecode($matches['value']),
+                                'utf-8',
+                                $matches['charset']
+                            );
+                        }
+                    }
+                    $options[trim($key)] = trim($value, ' "');
+                } else {
+                    // Bogus option
+                    $options[$partSplit[0]] = '';
+                }
+            }
+        }
+
+        return array($headerValue, $options);
+    }
+}

--- a/tests/Riverline/MultiPartParser/Converters/Commun.php
+++ b/tests/Riverline/MultiPartParser/Converters/Commun.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the MultiPartParser package.
+ *
+ * (c) Romain Cambien <romain@cambien.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Riverline\MultiPartParser\Converters;
+
+/**
+ * Class Commun
+ */
+class Commun extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return resource
+     */
+    public function createBodyStream()
+    {
+        $content = file_get_contents(__DIR__.'/../../../data/simple_multipart.txt');
+
+        list(, $body) = preg_split("/(\r\n){2}/", $content, 2);
+
+        $stream = fopen('php://temp', 'rw');
+        fwrite($stream, $body);
+
+        rewind($stream);
+
+        return $stream;
+    }
+}

--- a/tests/Riverline/MultiPartParser/Converters/GlobalsTest.php
+++ b/tests/Riverline/MultiPartParser/Converters/GlobalsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the MultiPartParser package.
+ *
+ * (c) Romain Cambien <romain@cambien.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Riverline\MultiPartParser\Converters;
+
+/**
+ * Class GlobalsTest
+ */
+class GlobalsTest extends Commun
+{
+    /**
+     * Test the parser
+     */
+    public function testParser()
+    {
+        // Create PSR7 server request
+
+        $_SERVER['HTTP_CONTENT_TYPE'] = 'multipart/form-data; boundary=----------------------------83ff53821b7c';
+
+        // Test the converter
+        $part = Globals::convert($this->createBodyStream());
+
+        self::assertTrue($part->isMultiPart());
+        self::assertCount(3, $part->getParts());
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("MultiPart content, there aren't body");
+        $part->getBody();
+    }
+}

--- a/tests/Riverline/MultiPartParser/Converters/HttpFoundationTest.php
+++ b/tests/Riverline/MultiPartParser/Converters/HttpFoundationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the MultiPartParser package.
+ *
+ * (c) Romain Cambien <romain@cambien.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Riverline\MultiPartParser\Converters;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class HttpFoundationTest
+ */
+class HttpFoundationTest extends Commun
+{
+    /**
+     * Test the parser
+     */
+    public function testParser()
+    {
+        $request = Request::create(
+            '/',
+            'GET',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'multipart/form-data; boundary=----------------------------83ff53821b7c'],
+            $this->createBodyStream()
+        );
+
+        // Test the converter
+        $part = HttpFoundation::convert($request);
+
+        self::assertTrue($part->isMultiPart());
+        self::assertCount(3, $part->getParts());
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("MultiPart content, there aren't body");
+        $part->getBody();
+    }
+}

--- a/tests/Riverline/MultiPartParser/Converters/PSR7Test.php
+++ b/tests/Riverline/MultiPartParser/Converters/PSR7Test.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the MultiPartParser package.
+ *
+ * (c) Romain Cambien <romain@cambien.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Riverline\MultiPartParser\Converters;
+
+use Zend\Diactoros\ServerRequest;
+
+/**
+ * Class PSR7Test
+ */
+class PSR7Test extends Commun
+{
+    /**
+     * Test the parser
+     */
+    public function testParser()
+    {
+        $request = new ServerRequest(
+            [],
+            [],
+            '/',
+            'GET',
+            $this->createBodyStream(),
+            ['Content-type' => 'multipart/form-data; boundary=----------------------------83ff53821b7c']
+        );
+
+        // Test the converter
+        $part = PSR7::convert($request);
+
+        self::assertTrue($part->isMultiPart());
+        self::assertCount(3, $part->getParts());
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("MultiPart content, there aren't body");
+        $part->getBody();
+    }
+}

--- a/tests/Riverline/MultiPartParser/PartTest.php
+++ b/tests/Riverline/MultiPartParser/PartTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpDeprecationInspection */
 
 /*
  * This file is part of the MultiPartParser package.
@@ -21,7 +21,8 @@ class PartTest extends \PHPUnit_Framework_TestCase
      */
     public function testEmptyPart()
     {
-        $this->setExpectedException('\LogicException', "Content is not valid");
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("Content is not valid");
         new Part('');
     }
 
@@ -37,7 +38,8 @@ class PartTest extends \PHPUnit_Framework_TestCase
         self::assertTrue($part->isMultiPart());
         self::assertCount(3, $part->getParts());
 
-        $this->setExpectedException('\LogicException', "MultiPart content, there aren't body");
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("MultiPart content, there aren't body");
         $part->getBody();
     }
 }

--- a/tests/Riverline/MultiPartParser/PartTest.php
+++ b/tests/Riverline/MultiPartParser/PartTest.php
@@ -13,7 +13,6 @@ namespace Riverline\MultiPartParser;
 
 /**
  * Class PartTest
- * @package Riverline\MultiPartParser
  */
 class PartTest extends \PHPUnit_Framework_TestCase
 {
@@ -24,52 +23,6 @@ class PartTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('\LogicException', "Content is not valid");
         new Part('');
-    }
-
-    /**
-     * Test a multipart document without boundary header
-     */
-    public function testNoBoundaryPart()
-    {
-        $content = file_get_contents(__DIR__.'/../../data/no_boundary.txt');
-
-        $this->setExpectedException('\LogicException', "Can't find boundary in content type");
-        new Part($content);
-    }
-
-    /**
-     * Test a multipart document without first boundary
-     */
-    public function testNoFirstBoundaryPart()
-    {
-        $content = file_get_contents(__DIR__.'/../../data/no_first_boundary.txt');
-
-        $this->setExpectedException('\LogicException', "Can't find multi-part content");
-        new Part($content);
-    }
-
-    /**
-     * Test a multipart document without last boundary
-     */
-    public function testNoLastBoundaryPart()
-    {
-        $content = file_get_contents(__DIR__.'/../../data/no_last_boundary.txt');
-
-        $this->setExpectedException('\LogicException', "Can't find multi-part content");
-        new Part($content);
-    }
-
-    /**
-     * Test a document without multipart
-     */
-    public function testNoMultiPart()
-    {
-        $content = file_get_contents(__DIR__.'/../../data/no_multipart.txt');
-
-        $part = new Part($content);
-
-        self::assertFalse($part->isMultiPart());
-        self::assertEquals('bar', $part->getBody());
     }
 
     /**
@@ -86,128 +39,5 @@ class PartTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException('\LogicException', "MultiPart content, there aren't body");
         $part->getBody();
-    }
-
-    /**
-     * Test multi line header
-     */
-    public function testMultiLineHeader()
-    {
-        $content = file_get_contents(__DIR__.'/../../data/simple_multipart.txt');
-
-        $part = new Part($content);
-
-        self::assertEquals('line one line two with space line three with tab', $part->getHeader('X-Multi-Line'));
-    }
-
-    /**
-     * Test filter by name on a simple multipart document
-     */
-    public function testFilterByName()
-    {
-        $content = file_get_contents(__DIR__.'/../../data/simple_multipart.txt');
-
-        $part = new Part($content);
-
-        self::assertCount(1, $part->getPartsByName('foo'));
-    }
-
-    /**
-     * Test correct part content (e.g. \r of separator not part of body)
-     */
-    public function testPartContent()
-    {
-        $content = file_get_contents(__DIR__.'/../../data/simple_multipart.txt');
-
-        $part = new Part($content);
-
-        $foo = $part->getPartsByName('foo');
-
-        self::assertEquals("bar", $foo[0]->getBody());
-    }
-
-    /**
-     * Test RFC 5987 encoded header
-     */
-    public function testRFC5987Header()
-    {
-        $content = file_get_contents(__DIR__.'/../../data/simple_multipart.txt');
-
-        $part = new Part($content);
-        $parts = $part->getParts();
-        $header = $parts[2]->getHeader('Content-Disposition');
-
-        self::assertEquals('£ rates', Part::getHeaderOption($header, 'text1'));
-        self::assertEquals('£ and € rates', Part::getHeaderOption($header, 'text2'));
-    }
-
-    /**
-     * Test header helpers
-     */
-    public function testHeaderHelpers()
-    {
-        $content = file_get_contents(__DIR__.'/../../data/simple_multipart.txt');
-
-        $part = new Part($content);
-        $parts = $part->getParts();
-        $header = $parts[1]->getHeader('Content-Disposition');
-
-        self::assertEquals('form-data', Part::getHeaderValue($header));
-        self::assertEquals('foo', Part::getHeaderOption($header, 'name'));
-    }
-
-    /**
-     * Test file helper
-     */
-    public function testFileHelper()
-    {
-        $content = file_get_contents(__DIR__.'/../../data/simple_multipart.txt');
-
-        $part = new Part($content);
-        $parts = $part->getParts();
-
-        self::assertTrue($parts[0]->isFile());
-        self::assertEquals('a.png', $parts[0]->getFileName());
-    }
-
-
-    /**
-     * Test a nested multipart document
-     */
-    public function testNestedMultiPart()
-    {
-        $content = file_get_contents(__DIR__.'/../../data/nested_multipart.txt');
-
-        $part = new Part($content);
-
-        self::assertTrue($part->isMultiPart());
-
-        /** @var Part[] $parts */
-        $parts = $part->getParts();
-
-        self::assertTrue($parts[0]->isMultiPart());
-    }
-
-    /**
-     * Test a email document with base64 encoding
-     */
-    public function testEmailBase64()
-    {
-        $content = file_get_contents(__DIR__.'/../../data/email_base64.txt');
-
-        $part = new Part($content);
-
-        self::assertTrue($part->isMultiPart());
-
-        $this->setExpectedException('\LogicException', "MultiPart content, there aren't body");
-        $part->getBody();
-
-        self::assertEquals('This is thé subject', $part->getHeader('Subject'));
-
-        /** @var Part[] $parts */
-        $parts = $part->getParts();
-
-        self::assertEquals('This is the content', $parts[0]->getBody());
-        self::assertEquals('This is the côntént', $parts[1]->getBody());
     }
 }

--- a/tests/Riverline/MultiPartParser/PartTest.php
+++ b/tests/Riverline/MultiPartParser/PartTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the MultiPartParser package.
+ *
+ * (c) Romain Cambien <romain@cambien.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Riverline\MultiPartParser;
 
 /**

--- a/tests/Riverline/MultiPartParser/StreamedPartTest.php
+++ b/tests/Riverline/MultiPartParser/StreamedPartTest.php
@@ -1,0 +1,184 @@
+<?php
+
+/*
+ * This file is part of the MultiPartParser package.
+ *
+ * (c) Romain Cambien <romain@cambien.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Riverline\MultiPartParser;
+
+/**
+ * Class StreamedPartTest
+ */
+class StreamedPartTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test a multipart document without boundary header
+     */
+    public function testNoBoundaryPart()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("Can't find boundary in content type");
+        new StreamedPart(fopen(__DIR__.'/../../data/no_boundary.txt', 'r'));
+    }
+
+    /**
+     * Test a multipart document without first boundary
+     */
+    public function testNoFirstBoundaryPart()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("Can't find multi-part content");
+        new StreamedPart(fopen(__DIR__.'/../../data/no_first_boundary.txt', 'r'));
+    }
+
+    /**
+     * Test a multipart document without last boundary
+     */
+    public function testNoLastBoundaryPart()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("Can't find multi-part content");
+        new StreamedPart(fopen(__DIR__.'/../../data/no_last_boundary.txt', 'r'));
+    }
+
+    /**
+     * Test a document without multipart
+     */
+    public function testNoMultiPart()
+    {
+        $part = new StreamedPart(fopen(__DIR__.'/../../data/no_multipart.txt', 'r'));
+
+        self::assertFalse($part->isMultiPart());
+        self::assertEquals('bar', $part->getBody());
+    }
+
+    /**
+     * Test a simple multipart document
+     */
+    public function testSimpleMultiPart()
+    {
+        $part = new StreamedPart(fopen(__DIR__.'/../../data/simple_multipart.txt', 'r'));
+
+        self::assertTrue($part->isMultiPart());
+        self::assertCount(3, $part->getParts());
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("MultiPart content, there aren't body");
+        $part->getBody();
+    }
+
+    /**
+     * Test multi line header
+     */
+    public function testMultiLineHeader()
+    {
+        $part = new StreamedPart(fopen(__DIR__.'/../../data/simple_multipart.txt', 'r'));
+
+        self::assertEquals('line one line two with space line three with tab', $part->getHeader('X-Multi-Line'));
+    }
+
+    /**
+     * Test filter by name on a simple multipart document
+     */
+    public function testFilterByName()
+    {
+        $part = new StreamedPart(fopen(__DIR__.'/../../data/simple_multipart.txt', 'r'));
+
+        self::assertCount(1, $part->getPartsByName('foo'));
+    }
+
+    /**
+     * Test correct part content (e.g. \r of separator not part of body)
+     */
+    public function testPartContent()
+    {
+        $part = new StreamedPart(fopen(__DIR__.'/../../data/simple_multipart.txt', 'r'));
+
+        $foo = $part->getPartsByName('foo');
+
+        self::assertEquals("bar", $foo[0]->getBody());
+    }
+
+    /**
+     * Test RFC 5987 encoded header
+     */
+    public function testRFC5987Header()
+    {
+        $part = new StreamedPart(fopen(__DIR__.'/../../data/simple_multipart.txt', 'r'));
+
+        $parts = $part->getParts();
+        $header = $parts[2]->getHeader('Content-Disposition');
+
+        self::assertEquals('£ rates', StreamedPart::getHeaderOption($header, 'text1'));
+        self::assertEquals('£ and € rates', StreamedPart::getHeaderOption($header, 'text2'));
+    }
+
+    /**
+     * Test header helpers
+     */
+    public function testHeaderHelpers()
+    {
+        $part = new StreamedPart(fopen(__DIR__.'/../../data/simple_multipart.txt', 'r'));
+
+        $parts = $part->getParts();
+        $header = $parts[1]->getHeader('Content-Disposition');
+
+        self::assertEquals('form-data', StreamedPart::getHeaderValue($header));
+        self::assertEquals('foo', StreamedPart::getHeaderOption($header, 'name'));
+    }
+
+    /**
+     * Test file helper
+     */
+    public function testFileHelper()
+    {
+        $part = new StreamedPart(fopen(__DIR__.'/../../data/simple_multipart.txt', 'r'));
+
+        $parts = $part->getParts();
+
+        self::assertTrue($parts[0]->isFile());
+        self::assertEquals('a.png', $parts[0]->getFileName());
+    }
+
+
+    /**
+     * Test a nested multipart document
+     */
+    public function testNestedMultiPart()
+    {
+        $part = new StreamedPart(fopen(__DIR__.'/../../data/nested_multipart.txt', 'r'));
+
+        self::assertTrue($part->isMultiPart());
+
+        $parts = $part->getParts();
+
+        self::assertTrue($parts[0]->isMultiPart());
+    }
+
+    /**
+     * Test a email document with base64 encoding
+     */
+    public function testEmailBase64()
+    {
+        $part = new StreamedPart(fopen(__DIR__.'/../../data/email_base64.txt', 'r'));
+
+        self::assertTrue($part->isMultiPart());
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("MultiPart content, there aren't body");
+        $part->getBody();
+
+        self::assertEquals('This is thé subject', $part->getHeader('Subject'));
+
+        /** @var Part[] $parts */
+        $parts = $part->getParts();
+
+        self::assertEquals('This is the content', $parts[0]->getBody());
+        self::assertEquals('This is the côntént', $parts[1]->getBody());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 
 /** @var \Composer\Autoload\ClassLoader $loader */
-$loader = @include(__DIR__ . '/../vendor/autoload.php');
+$loader = @include(__DIR__.'/../vendor/autoload.php');
 
 if (!$loader) {
     die("You must set up the project dependencies, run the following commands:


### PR DESCRIPTION
* Deprecate old parse (keep a wrapper class for BC)
* Remove use of preg_ function to avoid regexp size limit
* Bump min PHP version to 5.4.4 to avoid a bug with stream
* TODO: migrate tests and create new tests with stream