### PR TITLE
Allow setting a custom length of the EOL

### DIFF
--- a/src/Riverline/MultiPartParser/StreamedPart.php
+++ b/src/Riverline/MultiPartParser/StreamedPart.php
@@ -41,20 +41,22 @@ class StreamedPart
      *
      * @var int
      */
-    private static $EOLCharacterLength = 2;
+    private $EOLCharacterLength = 2;
 
     /**
      * StreamParser constructor.
      *
      * @param resource $stream
+     * @param int $EOLCharacterLength
      */
-    public function __construct($stream)
+    public function __construct($stream, $EOLCharacterLength = 2)
     {
         if (false === is_resource($stream)) {
             throw new \InvalidArgumentException('Input is not a stream');
         }
 
         $this->stream = $stream;
+        $this->EOLCharacterLength = $EOLCharacterLength;
 
         // Reset the stream
         rewind($this->stream);
@@ -154,13 +156,13 @@ class StreamedPart
                         // means that we are also at the end of the stream.
                         // we do not know if $eofLength is 1 or two, so we guess it to 2 (\r\n) since is more standard
                         if ($eofLength === 0 && feof($this->stream)) {
-                            $partLength = $currentOffset - $partOffset - strlen($line) - static::$EOLCharacterLength;
+                            $partLength = $currentOffset - $partOffset - strlen($line) - $this->EOLCharacterLength;
                         }
 
                         // Copy part in a new stream
                         $partStream = fopen('php://temp', 'rw');
                         stream_copy_to_stream($this->stream, $partStream, $partLength, $partOffset);
-                        $this->parts[] = new self($partStream);
+                        $this->parts[] = new self($partStream, $this->EOLCharacterLength);
                         // Reset current stream offset
                         fseek($this->stream, $currentOffset);
                     }
@@ -426,15 +428,5 @@ class StreamedPart
         }
 
         return array($headerValue, $options);
-    }
-
-    /**
-     * Set the EOL Length to a custom value.
-     *
-     * @param $length
-     */
-    public static function setEOLCharacterLength($length)
-    {
-        static::$EOLCharacterLength = $length;
     }
 }

--- a/src/Riverline/MultiPartParser/StreamedPart.php
+++ b/src/Riverline/MultiPartParser/StreamedPart.php
@@ -41,7 +41,7 @@ class StreamedPart
      *
      * @var int
      */
-    private $EOLCharacterLength = 2;
+    private $EOLCharacterLength;
 
     /**
      * StreamParser constructor.
@@ -53,6 +53,10 @@ class StreamedPart
     {
         if (false === is_resource($stream)) {
             throw new \InvalidArgumentException('Input is not a stream');
+        }
+
+        if (false === is_integer($EOLCharacterLength)) {
+            throw new \InvalidArgumentException('EOL Length is not an integer');
         }
 
         $this->stream = $stream;

--- a/src/Riverline/MultiPartParser/StreamedPart.php
+++ b/src/Riverline/MultiPartParser/StreamedPart.php
@@ -154,7 +154,8 @@ class StreamedPart
 
                         // if we are at the end of a part, and there is no trailing new line ($eofLength == 0)
                         // means that we are also at the end of the stream.
-                        // we do not know if $eofLength is 1 or two, so we guess it to 2 (\r\n) since is more standard
+                        // we do not know if $eofLength is 1 or two, so we'll use the EOLCharacterLength value
+                        // which is 2 by default.
                         if ($eofLength === 0 && feof($this->stream)) {
                             $partLength = $currentOffset - $partOffset - strlen($line) - $this->EOLCharacterLength;
                         }

--- a/src/Riverline/MultiPartParser/StreamedPart.php
+++ b/src/Riverline/MultiPartParser/StreamedPart.php
@@ -37,6 +37,13 @@ class StreamedPart
     private $parts = array();
 
     /**
+     * The length of the EOL character.
+     *
+     * @var int
+     */
+    private static $EOLCharacterLength = 2;
+
+    /**
      * StreamParser constructor.
      *
      * @param resource $stream
@@ -147,7 +154,7 @@ class StreamedPart
                         // means that we are also at the end of the stream.
                         // we do not know if $eofLength is 1 or two, so we guess it to 2 (\r\n) since is more standard
                         if ($eofLength === 0 && feof($this->stream)) {
-                            $partLength = $currentOffset - $partOffset - strlen($line) - 2;
+                            $partLength = $currentOffset - $partOffset - strlen($line) - static::$EOLCharacterLength;
                         }
 
                         // Copy part in a new stream
@@ -419,5 +426,15 @@ class StreamedPart
         }
 
         return array($headerValue, $options);
+    }
+
+    /**
+     * Set the EOL Length to a custom value.
+     *
+     * @param $length
+     */
+    public static function setEOLCharacterLength($length)
+    {
+        static::$EOLCharacterLength = $length;
     }
 }

--- a/tests/Riverline/MultiPartParser/StreamedPartTest.php
+++ b/tests/Riverline/MultiPartParser/StreamedPartTest.php
@@ -106,6 +106,30 @@ class StreamedPartTest extends TestCase
     }
 
     /**
+     * Test multipart without new line at the end
+     */
+    public function testNoNewLineAtTheEndOfThePartsWhenNewLineIsOneCharacterLong()
+    {
+        $content = "Content-Type: multipart/related; boundary=delimiter\n".
+            "\n" .
+            "--delimiter\n" .
+            "Content-Type:mime/type\n" .
+            "\n" .
+            "Content\n" .
+            "--delimiter--";
+
+
+        $stream = fopen('php://temp', 'rw');
+        fwrite($stream, $content);
+        rewind($stream);
+
+        $part = new StreamedPart($stream, 1);
+        /** @var Part[] $parts */
+        $parts = $part->getParts();
+        self::assertEquals('Content', $parts[0]->getBody());
+    }
+
+    /**
      * Test that is not possible to get parts for a not multi part document
      */
     public function testCantGetPartsForANotMultiPartMessage()


### PR DESCRIPTION
This PR just allows seting-up a custom length of the EOL instead of [guessing](https://github.com/Riverline/multipart-parser/blob/master/src/Riverline/MultiPartParser/StreamedPart.php#L148) it to 2.

I can also add a simple validation to make sure the new value is either 1 or 2.