### PR TITLE
#23 - test files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-/tests/data/* text eol=crlf
+/tests/data/* binary


### PR DESCRIPTION
#23 - instead of text with windows returns, handle them as binary

When cloning on a linux machine, these files are instantly modified, It seems like there is a delete character in these files that are 'executed' by git diff and therefor it thinks it's modified.

Currently testing if this solves it. This should handle the files as binary instead of as text with windows returns.