### PR TITLE
Allow converter to work with any HTTP message

### DIFF
--- a/src/Riverline/MultiPartParser/Converters/PSR7.php
+++ b/src/Riverline/MultiPartParser/Converters/PSR7.php
@@ -11,6 +11,7 @@
 
 namespace Riverline\MultiPartParser\Converters;
 
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Riverline\MultiPartParser\StreamedPart;
 
@@ -24,7 +25,7 @@ class PSR7
      *
      * @return StreamedPart
      */
-    public static function convert(ServerRequestInterface $serverRequest)
+    public static function convert(MessageInterface $serverRequest)
     {
         $stream = fopen('php://temp', 'rw');
 

--- a/src/Riverline/MultiPartParser/Converters/PSR7.php
+++ b/src/Riverline/MultiPartParser/Converters/PSR7.php
@@ -12,7 +12,6 @@
 namespace Riverline\MultiPartParser\Converters;
 
 use Psr\Http\Message\MessageInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Riverline\MultiPartParser\StreamedPart;
 
 /**
@@ -21,22 +20,22 @@ use Riverline\MultiPartParser\StreamedPart;
 class PSR7
 {
     /**
-     * @param ServerRequestInterface $serverRequest
+     * @param MessageInterface $message
      *
      * @return StreamedPart
      */
-    public static function convert(MessageInterface $serverRequest)
+    public static function convert(MessageInterface $message)
     {
         $stream = fopen('php://temp', 'rw');
 
-        foreach ($serverRequest->getHeaders() as $key => $values) {
+        foreach ($message->getHeaders() as $key => $values) {
             foreach ($values as $value) {
                 fwrite($stream, "$key: $value\r\n");
             }
         }
         fwrite($stream, "\r\n");
 
-        $body = $serverRequest->getBody();
+        $body = $message->getBody();
         $body->rewind();
 
         while (!$body->eof()) {


### PR DESCRIPTION
This PR relaxes the interface in `\Riverline\MultiPartParser\Converters\PSR7::convert` to accept any psr7 HTTP message instead of only `ServerRequestInterface`.

I am planning to use this packet in this package: https://github.com/lezhnev74/openapi-psr7-validator
And that's why I need to be able to parse multipart bodies of requests and responses.