### PR TITLE
Remove unused PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "ext-mbstring": "*"
   },
   "require-dev":{
-    "phpunit/phpunit":  "^4.8.35 || ^5.2 || ^6.0 || ^7.0",
+    "phpunit/phpunit":  "^5.2 || ^6.0 || ^7.0",
     "psr/http-message": "^1.0",
     "symfony/psr-http-message-bridge": "^1.1",
     "zendframework/zend-diactoros": "^1.0"


### PR DESCRIPTION
# Changed log
It seems that the package requires the `php-5.6` version at least.

It should let the PHPUnit version be `5.x` at least and remove the `4.8.x` version.

The reference is available [here](https://phpunit.de/getting-started/phpunit-5.html).