### PR TITLE
Add CONTENT_TYPE in $_SERVER to test situation

### DIFF
--- a/tests/Riverline/MultiPartParser/Converters/GlobalsTest.php
+++ b/tests/Riverline/MultiPartParser/Converters/GlobalsTest.php
@@ -25,9 +25,11 @@ class GlobalsTest extends Commun
      */
     protected function createPart()
     {
+        $contentType = 'multipart/form-data; boundary=----------------------------83ff53821b7c';
         // Create PSR7 server request
 
-        $_SERVER['HTTP_CONTENT_TYPE'] = 'multipart/form-data; boundary=----------------------------83ff53821b7c';
+        $_SERVER['HTTP_CONTENT_TYPE'] = $contentType;
+        $_SERVER['HTTP_CONTENT_LENGTH'] = strlen($contentType);
 
         // Test the converter
         return Globals::convert($this->createBodyStream());


### PR DESCRIPTION
# Changed log
- Add `CONTENT_TYPE` key and its value in global `$_SERVER` array to test the condition block when this key is existed.