### PR TITLE
removed abandoned package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "phpunit/phpunit":  "^5.2 || ^6.0 || ^7.0",
     "psr/http-message": "^1.0",
     "symfony/psr-http-message-bridge": "^1.1",
-    "zendframework/zend-diactoros": "^1.0"
+    "laminas/laminas-diactoros": "^1.8.7"
   },
   "autoload":{
     "psr-4":{

--- a/tests/Converters/PSR7Test.php
+++ b/tests/Converters/PSR7Test.php
@@ -11,8 +11,8 @@
 
 namespace Riverline\MultiPartParser\Converters;
 
+use Laminas\Diactoros\ServerRequest;
 use Riverline\MultiPartParser\StreamedPart;
-use Zend\Diactoros\ServerRequest;
 
 /**
  * Class PSR7Test


### PR DESCRIPTION
Composer is complaining about zendframework/zend-diactoros

> Package zendframework/zend-diactoros is abandoned, you should avoid using it. Use laminas/laminas-diactoros instead.

therefore I followed the given recommendation

- removed zend-diactoros dependency
- added laminas-diactoros 1.8.7 (newer versions require php 7 and multipart parser itself is php 5.6 compatible)

I've run the tests and everything worked (used PHP 7.3)