### PR TITLE
StreamedPart: Replace \LogicException with \InvalidArgumentException in constructor

### DIFF
--- a/src/StreamedPart.php
+++ b/src/StreamedPart.php
@@ -48,6 +48,8 @@ class StreamedPart
      *
      * @param resource $stream
      * @param int $EOLCharacterLength
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct($stream, $EOLCharacterLength = 2)
     {

--- a/src/StreamedPart.php
+++ b/src/StreamedPart.php
@@ -187,7 +187,7 @@ class StreamedPart
             if (0 === count($this->parts)
                 || false === $endOfBody
             ) {
-                throw new \LogicException("Can't find multi-part content");
+                throw new \InvalidArgumentException("Can't find multi-part content");
             }
         }
     }

--- a/tests/StreamedPartTest.php
+++ b/tests/StreamedPartTest.php
@@ -53,7 +53,7 @@ class StreamedPartTest extends TestCase
      */
     public function testNoFirstBoundaryPart()
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage("Can't find multi-part content");
         new StreamedPart(fopen(__DIR__ . '/_data/no_first_boundary.txt', 'r'));
     }
@@ -63,7 +63,7 @@ class StreamedPartTest extends TestCase
      */
     public function testNoLastBoundaryPart()
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage("Can't find multi-part content");
         new StreamedPart(fopen(__DIR__ . '/_data/no_last_boundary.txt', 'r'));
     }


### PR DESCRIPTION
I think at this point an `\InvalidArgumentException` makes more sense.

This change should not create BC problems because `\InvalidArgumentException` is a subclass of `\LogicException`.