### PR TITLE
Some fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
   ],
   "require":{
     "php":          ">=5.6.0",
-    "ext-mbstring": "*"
+    "ext-mbstring": "*",
+    "ralouphie/getallheaders": "^3.0"
   },
   "require-dev":{
     "phpunit/phpunit":  "^5.2 || ^6.0 || ^7.0",

--- a/src/Converters/Globals.php
+++ b/src/Converters/Globals.php
@@ -58,11 +58,23 @@ class Globals
             return $input;
         }
 
-        return self::getStdinStream();
+        return self::getDefaultStream();
     }
 
-    static private function getStdinStream()
+    static private function getDefaultStream()
     {
-        return fopen('php://stdin', 'r');
+        $filename = self::getDefaultRequestStreamFilename();
+
+        return fopen($filename, 'r');
+    }
+
+    static private function getDefaultRequestStreamFilename()
+    {
+        return self::isCliSapi() ? 'php://stdin' : 'php://input';
+    }
+
+    static private function isCliSapi()
+    {
+        return strpos(PHP_SAPI, 'cli') !== false;
     }
 }

--- a/src/Converters/Globals.php
+++ b/src/Converters/Globals.php
@@ -19,11 +19,11 @@ use Riverline\MultiPartParser\StreamedPart;
 class Globals
 {
     /**
-     * @param bool|resource $input
+     * @param resource|null $input
      *
      * @return StreamedPart
      */
-    public static function convert($input = STDIN)
+    public static function convert($input = null)
     {
         $stream = fopen('php://temp', 'rw');
 
@@ -38,11 +38,29 @@ class Globals
         }
 
         fwrite($stream, "\r\n");
-
-        stream_copy_to_stream($input, $stream);
+        $inputStream = self::getInputStreamByInput($input);
+        stream_copy_to_stream($inputStream, $stream);
 
         rewind($stream);
 
         return new StreamedPart($stream);
+    }
+
+    /**
+     * @param resource|null $input
+     * @return resource
+     */
+    static private function getInputStreamByInput($input = null)
+    {
+        if (is_resource($input)) {
+            return $input;
+        }
+
+        return self::getStdinStream();
+    }
+
+    static private function getStdinStream()
+    {
+        return fopen('php://stdin', 'r');
     }
 }


### PR DESCRIPTION
1) Fix usage STDIN constant as parameter default value in \Riverline\MultiPartParser\Converters\Globals::convert().
2) Use `php://stdin` or `php://input` depends on SAPI.
3) Create Header block in temporary stream by `getallheaders()` instead of `$_SERVER` gloabl variable.
4) Add `getallheaders()` polyfill.


# 1) Fix usage `STDIN` constant as parameter default value in \Riverline\MultiPartParser\Converters\Globals::convert().
`STDIN` constant defined [only in CLI SAPI](https://www.php.net/manual/en/features.commandline.io-streams.php) so when it used in other SAPI it produce notice like: `Use of undefined constant STDIN - assumed 'STDIN' in ...`.

# 2) Use `php://stdin` or `php://input` depends on SAPI.
Use `php://stdin` if SAPI contains `cli` string. Not sure that it was rigth way, but it's better then before :)

# 3) Create Header of temporary stream by `getallheaders()` instead of `$_SERVER` gloabl variable.
Iterating over $_SERVER global variable instantinate multiple `Content-Type` headers, because in some configurations `$_SERVER` contains both `HTTP_CONTENT_TYPE` and `CONTENT_TYPE` keys. Therefore header with key `content-type` becomes an array. So in \Riverline\MultiPartParser\StreamedPart::parseHeaderContent() an Error will thown on `$parts = explode(';', $content);`.

# 4) Add `getallheaders()` polyfill.
In some configurations `getallheaders()` could be not defined.