### PR TITLE
Fixes PHP 8.1 deprecated features

### DIFF
--- a/src/StreamedPart.php
+++ b/src/StreamedPart.php
@@ -219,7 +219,7 @@ class StreamedPart
         $body = stream_get_contents($this->stream, -1, $this->bodyOffset);
 
         // Decode
-        $encoding = strtolower($this->getHeader('Content-Transfer-Encoding'));
+        $encoding = strtolower((string) $this->getHeader('Content-Transfer-Encoding'));
         switch ($encoding) {
             case 'base64':
                 $body = base64_decode($body);
@@ -400,7 +400,7 @@ class StreamedPart
      */
     private static function parseHeaderContent($content)
     {
-        $parts = explode(';', $content);
+        $parts = explode(';', (string) $content);
         $headerValue = array_shift($parts);
         $options = array();
         // Parse options


### PR DESCRIPTION
This pull request fixes some features that are not working with PHP 8.1, more precisely both `strtolower` and `explore` no longer can work with `null` values.