### PR TITLE
Add paths and folders to be export-ignored to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
 /tests/_data/* binary
+
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml.dist   export-ignore
+/tests


### PR DESCRIPTION
Add paths to `.gitattributes` with the `export-ignore` flag set, so they're not pulled down as part of a project's dependencies via Composer.