### PR TITLE
Remove parameter EOLCharacterLength and detect it automatically

### DIFF
--- a/src/StreamedPart.php
+++ b/src/StreamedPart.php
@@ -37,30 +37,17 @@ class StreamedPart
     private $parts = array();
 
     /**
-     * The length of the EOL character.
-     *
-     * @var int
-     */
-    private $EOLCharacterLength;
-
-    /**
      * StreamParser constructor.
      *
      * @param resource $stream
-     * @param int $EOLCharacterLength
      */
-    public function __construct($stream, $EOLCharacterLength = 2)
+    public function __construct($stream)
     {
         if (false === is_resource($stream)) {
             throw new \InvalidArgumentException('Input is not a stream');
         }
 
-        if (false === is_integer($EOLCharacterLength)) {
-            throw new \InvalidArgumentException('EOL Length is not an integer');
-        }
-
         $this->stream = $stream;
-        $this->EOLCharacterLength = $EOLCharacterLength;
 
         // Reset the stream
         rewind($this->stream);
@@ -145,6 +132,8 @@ class StreamedPart
 
             $partOffset = 0;
             $endOfBody = false;
+            $eofLength = 0;
+
             while ($line = fgets($this->stream, $bufferSize)) {
                 $trimmed = rtrim($line, "\r\n");
 
@@ -152,22 +141,12 @@ class StreamedPart
                 if ($trimmed === $separator || $trimmed === $separator.'--') {
                     if ($partOffset > 0) {
                         $currentOffset = ftell($this->stream);
-                        // Get end of line length (should be 2)
-                        $eofLength = strlen($line) - strlen($trimmed);
-                        $partLength = $currentOffset - $partOffset - strlen($trimmed) - (2 * $eofLength);
-
-                        // if we are at the end of a part, and there is no trailing new line ($eofLength == 0)
-                        // means that we are also at the end of the stream.
-                        // we do not know if $eofLength is 1 or two, so we'll use the EOLCharacterLength value
-                        // which is 2 by default.
-                        if ($eofLength === 0 && feof($this->stream)) {
-                            $partLength = $currentOffset - $partOffset - strlen($line) - $this->EOLCharacterLength;
-                        }
+                        $partLength = $currentOffset - $partOffset - strlen($line) - $eofLength;
 
                         // Copy part in a new stream
                         $partStream = fopen('php://temp', 'rw');
                         stream_copy_to_stream($this->stream, $partStream, $partLength, $partOffset);
-                        $this->parts[] = new self($partStream, $this->EOLCharacterLength);
+                        $this->parts[] = new self($partStream);
                         // Reset current stream offset
                         fseek($this->stream, $currentOffset);
                     }
@@ -181,6 +160,9 @@ class StreamedPart
                     // Update the part offset
                     $partOffset = ftell($this->stream);
                 }
+
+                // Get end of line length (should be 2)
+                $eofLength = strlen($line) - strlen($trimmed);
             }
 
 

--- a/tests/StreamedPartTest.php
+++ b/tests/StreamedPartTest.php
@@ -29,16 +29,6 @@ class StreamedPartTest extends TestCase
     }
 
     /**
-     * Test a multipart with invalid EOL character length
-     */
-    public function testInvalidEOLCharacterLength()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage("EOL Length is not an integer");
-        new StreamedPart(fopen(__DIR__ . '/_data/no_boundary.txt', 'r'), 'invalid EOL character length');
-    }
-
-    /**
      * Test a multipart document without boundary header
      */
     public function testNoBoundaryPart()

--- a/tests/StreamedPartTest.php
+++ b/tests/StreamedPartTest.php
@@ -143,7 +143,7 @@ class StreamedPartTest extends TestCase
         fwrite($stream, $content);
         rewind($stream);
 
-        $part = new StreamedPart($stream, 1);
+        $part = new StreamedPart($stream);
         /** @var Part[] $parts */
         $parts = $part->getParts();
         self::assertEquals('Content', $parts[0]->getBody());


### PR DESCRIPTION
Take a look at this line: https://github.com/Riverline/multipart-parser/blob/caad7d92aeb5c61cf54b9365416e5e87d93e4c84/src/StreamedPart.php#L157

I was wondering, why `$eofLength` had to be multiplied with `2`. Then I realized, this was to necessary to remove the length of the delimiter plus the EOL after the delimiter plus the EOL in the previous line.

I realized, this could be an issue. When the EOL character length varies between the previous and the current line, this approach would fail. So I changed it to remove the length of `$line` instead of `$trimmed`, so the current EOL is already subtracted. Then I only have to subtract one `$eofLength`. But it must be the EOL character length of the previous line. So now, at the end of each iteration, I keep track of the EOL character length.

This entirely obsoletes the constructor parameter `$EOLCharacterLength`, because now it is fully dynamic. So, I removed this parameter. I no not see this as a breaking change as using excess parameters in object initialization does not fail and raises no warning.

I changed the tests accordingly, so they pass again. But to prove my point, I split my pull-request in two commits. The first commit removed the parameter for `$EOLCharacterLength` from the test-case `testNoNewLineAtTheEndOfThePartsWhenNewLineIsOneCharacterLong`. This makes the test fail. The second commit changes the implementation of `StreamedPart` and now the test passes again.