### PR TITLE
fix: Make "isMultiPart" method case-insensitive

### DIFF
--- a/src/StreamedPart.php
+++ b/src/StreamedPart.php
@@ -180,11 +180,11 @@ class StreamedPart
      */
     public function isMultiPart()
     {
-        return ('multipart' === mb_strstr(
+        return ('multipart' === mb_strtolower(mb_strstr(
             self::getHeaderValue($this->getHeader('Content-Type')),
             '/',
             true
-        ));
+        )));
     }
 
     /**

--- a/tests/StreamedPartTest.php
+++ b/tests/StreamedPartTest.php
@@ -292,4 +292,15 @@ class StreamedPartTest extends TestCase
         self::assertEquals('This is the content', $parts[0]->getBody());
         self::assertEquals('This is the côntént', $parts[1]->getBody());
     }
+
+    /**
+     * Test capitalized content type like "Multipart/Related"
+     */
+    public function testCapitalized()
+    {
+        $part = new StreamedPart(fopen(__DIR__ . '/_data/capitalized_multipart.txt', 'r'));
+
+        self::assertTrue($part->isMultiPart());
+    }
+
 }

--- a/tests/_data/capitalized_multipart.txt
+++ b/tests/_data/capitalized_multipart.txt
@@ -1,0 +1,16 @@
+server: nginx
+content-type: Multipart/Related; boundary="----=_Part_38_1747705778.1682694328571"; type="application/xop+xml"; start-info="text/xml"
+accept: text/xml, text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
+cache-control: no-cache, no-store, max-age=0, must-revalidate
+
+------=_Part_38_1747705778.1682694328571
+Content-Type: text/xml
+
+<root>
+  <person>
+    <name>John Doe</name>
+    <age>25</age>
+    <city>New York</city>
+  </person>
+</root>
+------=_Part_38_1747705778.1682694328571--


### PR DESCRIPTION
Hello, this PR makes content type detection case-insensitive.

I was receiving a request with the following content-type in the header:

```yaml
content-type: Multipart/Related; boundary="----=_Part_39_1947933869.1682695407509"; 
```

As you can see `content-type` header is capitalized: `Multipart/Related` instead of `multipart/related`.
With previous header `\Riverline\MultiPartParser\StreamedPart::isMultiPart` returned _false_, so I modified this method to be capable to handle these kind of `content-type` headers. 

I also added a test, I am open to any change request. Thanks.

