### PR TITLE
Do not try to detect encoding on binary data (#57)

### DIFF
--- a/src/StreamedPart.php
+++ b/src/StreamedPart.php
@@ -218,10 +218,12 @@ class StreamedPart
                 break;
         }
 
+        $contentType = $this->getHeader('Content-Type');
+        $isBinary = strtolower($contentType) === 'application/octet-stream';
+
         // Convert to UTF-8 ( Not if binary or 7bit ( aka Ascii ) )
-        if (false === in_array($encoding, array('binary', '7bit'))) {
+        if (! $isBinary && false === in_array($encoding, array('binary', '7bit'))) {
             // Charset
-            $contentType = $this->getHeader('Content-Type');
             $charset = self::getHeaderOption($contentType, 'charset');
             if (null === $charset) {
                 // Try to detect

--- a/tests/StreamedPartTest.php
+++ b/tests/StreamedPartTest.php
@@ -301,6 +301,24 @@ class StreamedPartTest extends TestCase
     }
 
     /**
+     * Test binary file with base64 encoding
+     */
+    public function testBase64WithOctetStream()
+    {
+        $part = new StreamedPart(fopen(__DIR__ . '/_data/binary_base64.txt', 'r'));
+
+        self::assertTrue($part->isMultiPart());
+
+        /** @var Part[] $parts */
+        $parts = $part->getParts();
+
+        self::assertCount(2, $parts);
+        self::assertEquals('bar', $parts[0]->getBody());
+        self::assertEquals('test.bin', $parts[1]->getFileName());
+        self::assertEquals(hex2bin('6566ffff'), $parts[1]->getBody());
+    }
+
+    /**
      * Test a quoted printable decoding
      */
     public function testQuotedPrintable()

--- a/tests/_data/binary_base64.txt
+++ b/tests/_data/binary_base64.txt
@@ -1,0 +1,21 @@
+User-Agent: curl/7.21.2 (x86_64-apple-darwin)
+Host: localhost:8080
+Accept: */*
+Content-Length: 1143
+Expect: 100-continue
+X-Multi-Line: line one
+    line two with space
+	line three with tab
+Content-Type: multipart/form-data; boundary=----------------------------83ff53821b7c
+
+------------------------------83ff53821b7c
+Content-Disposition: form-data; name="foo"
+
+bar
+------------------------------83ff53821b7c
+Content-Type: Application/octet-stream
+Content-Disposition: attachment; filename="test.bin"
+Content-Transfer-Encoding: base64
+
+ZWb//w==
+------------------------------83ff53821b7c--


### PR DESCRIPTION
Hi, this issue fixes #57: If the Content-Type says it is binary data, the content should not be converted to any charset.